### PR TITLE
Fix for mounts not despawning when using an ender pearl

### DIFF
--- a/src/main/java/com/ardacraft/ardastuff/mixin/EnderPearlEntityMixin.java
+++ b/src/main/java/com/ardacraft/ardastuff/mixin/EnderPearlEntityMixin.java
@@ -1,0 +1,52 @@
+package com.ardacraft.ardastuff.mixin;
+
+import com.llamalad7.mixinextras.sugar.Local;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.projectile.thrown.EnderPearlEntity;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.text.Text;
+import net.minecraft.util.hit.HitResult;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(EnderPearlEntity.class)
+public class EnderPearlEntityMixin {
+    @Unique
+    private Entity mount;
+
+    /**
+     * Captures a player's mount when a thrown ender pearl lands.
+     */
+    @Inject(method = "onCollision", at = @At("HEAD"))
+    private void captureMount(HitResult hitResult, CallbackInfo ci) {
+        Entity entity = ((EnderPearlEntity) (Object) this).getOwner();
+        if (entity instanceof ServerPlayerEntity && entity.hasVehicle()) {
+            Entity mount = entity.getVehicle();
+            Text text = mount != null ? mount.getCustomName() : null;
+            if (text != null && text.getString().equals("deleteme")) {
+                this.mount = mount;
+            }
+        }
+    }
+
+    /**
+     * Discards a player's mount, if necessary, when a thrown ender pearl lands.
+     */
+    @Inject(
+            method = "onCollision",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/server/network/ServerPlayerEntity;requestTeleportAndDismount(DDD)V",
+                    shift = At.Shift.AFTER
+            )
+    )
+    private void afterTeleport(CallbackInfo ci, @Local Entity entity) {
+        if (mount != null) {
+            mount.discard();
+            this.mount = null;
+        }
+    }
+}

--- a/src/main/resources/ardastuff.mixins.json
+++ b/src/main/resources/ardastuff.mixins.json
@@ -13,6 +13,7 @@
     "CropGrowthMixin",
     "EggEntityMixin",
     "EndCrystalMixin",
+    "EnderPearlEntityMixin",
     "EntityBucketItemMixin",
     "EntityMixin",
     "FallingBlockMixin",


### PR DESCRIPTION
Fixes the issue where boats and horses would not despawn when an ender pearl is used while riding them.

As it stands, using an ender pearl while riding a horse simply despawns the horse and does not teleport the user. When performing the same action in a boat, the user is teleported. This is because Minecraft handles the despawning of VehicleEntities and LivingEntities differently. The bug has been intentially left in because, to fix it robustly and to the standard I would like, ArdaStuff would require a cleanup and rewrite.